### PR TITLE
Use modfile parser

### DIFF
--- a/lib/mod.go
+++ b/lib/mod.go
@@ -7,6 +7,8 @@ import (
 )
 
 func getModder(lang string) (modder.Modder, error) {
+	// TODO try to detect language by looking for
+	// a [lang].mod file
 	mod, ok := modder.ModderMap[lang]
 	if !ok {
 		return nil, fmt.Errorf("Unknown language %q. Add configuration at https://github.com/hofstadter-io/mvs/blob/master/lib/modder/langs.go", lang)

--- a/lib/mod/module.go
+++ b/lib/mod/module.go
@@ -18,11 +18,12 @@ type Require struct {
 }
 
 type Replace struct {
-	Path   string
-	Source string
+	OldPath    string
+	OldVersion string
+	NewPath    string
+	NewVersion string
 }
 
 // If no lang.sum, calc sum, degenerate of next
 // if both, look for differences, calc sumc
 // if diff, fetch and do normal thing
-

--- a/lib/modder/simple.go
+++ b/lib/modder/simple.go
@@ -27,25 +27,39 @@ func (m *SimpleModder) Init(module string) error {
 	// make sure file does not exist
 	_, err := ioutil.ReadFile(filename)
 	// we read the file and it exists
-	if err == nil { return fmt.Errorf("%s already exists", filename) }
+	if err == nil {
+		return fmt.Errorf("%s already exists", filename)
+	}
 	// error was not path error, so return
-	if _, ok := err.(*os.PathError); !ok { return err }
+	if _, ok := err.(*os.PathError); !ok {
+		return err
+	}
 
 	// Create empty modfile
 	f, err := modfile.Parse(filename, nil, nil)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 
 	err = f.AddModuleStmt(module)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 
 	err = f.AddLanguageStmt(lang, m.Version)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 
 	bytes, err := f.Format()
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 
 	err = ioutil.WriteFile(filename, bytes, 0644)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
Example:

$ cat cue.mod
module example.org/cueblah

cue 1.0

require (
    github.com/go-git/go-billy/v5 v5.0.0
    github.com/go-git/go-git/v5 v5.0.0
    github.com/spf13/cobra v0.0.6
    golang.org/x/mod v0.2.0
    gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
)

$ # mvs vendor is currently setup to just read and print
$ mvs vendor -l cue
Module Contents:
language: cue
langver: "1.0"
module: example.org/cueblah
version: ""
require:
  - path: github.com/go-git/go-billy/v5
    version: v5.0.0
  - path: github.com/go-git/go-git/v5
    version: v5.0.0
  - path: github.com/spf13/cobra
    version: v0.0.6
  - path: golang.org/x/mod
    version: v0.2.0
  - path: gopkg.in/yaml.v3
    version: v3.0.0-20200313102051-9f266ea9e77c
replace: []
summod: null